### PR TITLE
proto: fix documentation for endpoints parameter

### DIFF
--- a/proto/orijtech/cosmosloadtester/v1/loadtest_service.pb.go
+++ b/proto/orijtech/cosmosloadtester/v1/loadtest_service.pb.go
@@ -160,7 +160,7 @@ type RunLoadtestRequest struct {
 	// The broadcast_tx method to use when submitting transactions - can be async, sync or commit.
 	// Maps to --broadcast-tx-method in tm-load-test.
 	BroadcastTxMethod RunLoadtestRequest_BroadcastTxMethod `protobuf:"varint,8,opt,name=broadcast_tx_method,json=broadcastTxMethod,proto3,enum=orijtech.cosmosloadtester.v1.RunLoadtestRequest_BroadcastTxMethod" json:"broadcast_tx_method,omitempty"`
-	// A comma-separated list of URLs indicating Tendermint WebSockets RPC endpoints to which to connect.
+	// A list of URLs indicating Tendermint WebSockets RPC endpoints to which to connect.
 	// Maps to --endpoints in tm-load-test.
 	Endpoints []string `protobuf:"bytes,9,rep,name=endpoints,proto3" json:"endpoints,omitempty"`
 	// The method by which to select endpoints.

--- a/proto/orijtech/cosmosloadtester/v1/loadtest_service.proto
+++ b/proto/orijtech/cosmosloadtester/v1/loadtest_service.proto
@@ -47,7 +47,7 @@ message RunLoadtestRequest {
   // The broadcast_tx method to use when submitting transactions - can be async, sync or commit.
   // Maps to --broadcast-tx-method in tm-load-test.
   BroadcastTxMethod broadcast_tx_method = 8;
-  // A comma-separated list of URLs indicating Tendermint WebSockets RPC endpoints to which to connect.
+  // A list of URLs indicating Tendermint WebSockets RPC endpoints to which to connect.
   // Maps to --endpoints in tm-load-test.
   repeated string endpoints = 9;
   enum EndpointSelectMethod {

--- a/proto/orijtech/cosmosloadtester/v1/loadtest_service.swagger.json
+++ b/proto/orijtech/cosmosloadtester/v1/loadtest_service.swagger.json
@@ -143,7 +143,7 @@
           "items": {
             "type": "string"
           },
-          "description": "A comma-separated list of URLs indicating Tendermint WebSockets RPC endpoints to which to connect.\nMaps to --endpoints in tm-load-test."
+          "description": "A list of URLs indicating Tendermint WebSockets RPC endpoints to which to connect.\nMaps to --endpoints in tm-load-test."
         },
         "endpointSelectMethod": {
           "$ref": "#/definitions/RunLoadtestRequestEndpointSelectMethod",

--- a/ui/src/gen/LoadtestApi.ts
+++ b/ui/src/gen/LoadtestApi.ts
@@ -97,7 +97,7 @@ export interface V1RunLoadtestRequest {
   broadcastTxMethod?: RunLoadtestRequestBroadcastTxMethod;
 
   /**
-   * A comma-separated list of URLs indicating Tendermint WebSockets RPC endpoints to which to connect.
+   * A list of URLs indicating Tendermint WebSockets RPC endpoints to which to connect.
    * Maps to --endpoints in tm-load-test.
    */
   endpoints?: string[];


### PR DESCRIPTION
I overaggressively copy-pasted the tm-load-test parameter descriptions. For our RPC, the caller should supply a list of strings, rather than a single, comma-separated string.