### PR TITLE
server: miscellaneous bugfixes and improvements

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,6 +7,8 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"os"
+	"os/signal"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -101,7 +103,13 @@ func main() {
 		Handler: wrappedHandler,
 	}
 	logrus.Infof("Serving gRPC-Gateway on http://%s", gwServer.Addr)
-	logrus.Fatalln(gwServer.ListenAndServe())
+	go func() {
+		logrus.Fatalln(gwServer.ListenAndServe())
+	}()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	<-sigCh
 }
 
 // Add logic to register your custom client factories to this function.


### PR DESCRIPTION
changes include:
* exit on interrupt signal rather than blocking on gwServer.listenAndServe()
* use correct stats output file path
* validate config before running loadtest
* properly map endpoint select methods

Updates https://github.com/orijtech/cosmosloadtester/issues/8